### PR TITLE
Document stream server flow and configuration

### DIFF
--- a/src/StreamServer.cpp
+++ b/src/StreamServer.cpp
@@ -4,8 +4,11 @@
 
 httpd_handle_t stream_httpd = NULL;
 
+// MIME type for MJPEG stream with frame boundary marker
 static const char* _STREAM_CONTENT_TYPE = "multipart/x-mixed-replace; boundary=frame";
+// Delimiter between JPEG frames in the multipart response
 static const char* _STREAM_BOUNDARY = "\r\n--frame\r\n";
+// Template for each part's headers indicating JPEG data and its length
 static const char* _STREAM_PART = "Content-Type: image/jpeg\r\nContent-Length: %u\r\n\r\n";
 
 static esp_err_t stream_handler(httpd_req_t *req) {
@@ -13,10 +16,12 @@ static esp_err_t stream_handler(httpd_req_t *req) {
   esp_err_t res = ESP_OK;
   char part_buf[64];
 
+  // Tell the client to expect multipart MJPEG stream
   res = httpd_resp_set_type(req, _STREAM_CONTENT_TYPE);
   if (res != ESP_OK) return res;
 
   while (true) {
+    // Grab a frame from the camera
     fb = esp_camera_fb_get();
     if (!fb) {
       res = ESP_FAIL;
@@ -24,6 +29,7 @@ static esp_err_t stream_handler(httpd_req_t *req) {
     }
 
     if (fb->format != PIXFORMAT_JPEG) {
+      // Convert frame buffer to JPEG if not already
       bool jpeg_converted = frame2jpg(fb, 80, (uint8_t**)&fb->buf, &fb->len);
       if (!jpeg_converted) {
         esp_camera_fb_return(fb);
@@ -32,6 +38,8 @@ static esp_err_t stream_handler(httpd_req_t *req) {
       }
     }
 
+    // Send the JPEG as a multipart HTTP response:
+    // first the part header, then the image data, then the boundary marker
     size_t hlen = snprintf(part_buf, sizeof(part_buf), _STREAM_PART, fb->len);
     res = httpd_resp_send_chunk(req, part_buf, hlen);
     if (res == ESP_OK)
@@ -46,9 +54,13 @@ static esp_err_t stream_handler(httpd_req_t *req) {
   return res;
 }
 
+/**
+ * Start HTTP server dedicated to MJPEG streaming.
+ * Uses port 81 and registers stream_handler for the "/stream" URI.
+ */
 void startStreamServer() {
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
-  config.server_port = 81;
+  config.server_port = 81; // Use a port different from the main web server
 
   httpd_uri_t stream_uri = {
     .uri       = "/stream",
@@ -58,6 +70,7 @@ void startStreamServer() {
   };
 
   if (httpd_start(&stream_httpd, &config) == ESP_OK) {
+    // Register handler that serves the stream when /stream is requested
     httpd_register_uri_handler(stream_httpd, &stream_uri);
   }
 }


### PR DESCRIPTION
## Summary
- Explain multipart MJPEG stream constants and their HTTP roles
- Comment frame capture, JPEG conversion, and multipart chunking in stream_handler
- Document port 81 configuration and URI handler registration in startStreamServer

## Testing
- `pio test` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688e9da568dc8322b52ef649478f282e