### PR TITLE
Clarify WiFi manager operations

### DIFF
--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -1,7 +1,10 @@
 #ifndef WIFI_MANAGER_H
 #define WIFI_MANAGER_H
 
+// Connect to WiFi using credentials saved in preferences.
 bool connectToStoredWiFi();
+
+// Start an access point and serve a configuration portal for new credentials.
 void startConfigPortal();
 
 #endif


### PR DESCRIPTION
## Summary
- Comment preference handling, retry logic, and fail counter updates in `connectToStoredWiFi`
- Document HTML form creation and save handler in `startConfigPortal`
- Add function summaries to WiFiManager header

## Testing
- `platformio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688e9daaf710832293dc6b12fa52991b