### PR TITLE
Document brownout and servo utilities

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -7,10 +7,16 @@ extern Servo servo1;
 extern Servo servo2;
 
 void disableBrownout() {
-  WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); // Disable brownout detector
+  // The ESP32-CAM is sensitive to brief voltage drops when peripherals
+  // such as the camera or servos draw peak current. Those dips can
+  // trigger the on-chip brownout detector and cause an unexpected
+  // reset, so the detector is disabled to keep the device running.
+  WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0);
 }
 
 void setupServos() {
-  servo1.setPeriodHertz(50); // 50Hz standard servo
+  // Standard hobby servos expect a 20ms refresh period (50 Hz). Using
+  // this rate provides full range of motion and avoids jitter.
+  servo1.setPeriodHertz(50);
   servo2.setPeriodHertz(50);
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -1,7 +1,16 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+/**
+ * Disable the ESP32's brownout detector to prevent unwanted resets
+ * during brief voltage dips caused by high current draw.
+ */
 void disableBrownout();
+
+/**
+ * Configure the servos to run at a 50 Hz PWM frequency, the standard
+ * refresh rate for most hobby servos.
+ */
 void setupServos();
 
 #endif


### PR DESCRIPTION
## Summary
- clarify why brownout detection is disabled to avoid unnecessary resets
- explain choice of 50 Hz refresh rate when configuring servos
- document utility functions with brief descriptions

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_688e9dadc6148322b90a8c76d3060199