### PR TITLE
Reuse single web server for camera and config portal

### DIFF
--- a/src/CameraServer.cpp
+++ b/src/CameraServer.cpp
@@ -18,10 +18,8 @@ Servo servo1, servo2;
 int servo1Pos = 90;
 int servo2Pos = 90;
 
-AsyncWebServer camServer(80);
-
 void startCameraServer() {
-  camServer.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
     // Serve a simple page with buttons that tilt and pan the camera
     String html = "<html><body><h2>ESP32-CAM Control</h2>";
     html += "<button onclick=\"fetch('/action?go=up')\">Up</button> ";
@@ -34,7 +32,7 @@ void startCameraServer() {
     request->send(200, "text/html", html);
   });
 
-  camServer.on("/action", HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on("/action", HTTP_GET, [](AsyncWebServerRequest *request){
     // Adjust servo positions according to the requested direction
     if (request->hasParam("go")) {
       String dir = request->getParam("go")->value();
@@ -48,7 +46,7 @@ void startCameraServer() {
     request->send(200, "text/plain", "OK");
   });
 
-  camServer.begin();
+  server.begin();
 }
 
 void setupCamera() {

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -41,12 +41,11 @@ bool connectToStoredWiFi() {
     preferences.end();
 
     if (failCount >= 3) {
-      Serial.println("WiFi failed 3 times. Resetting credentials and starting AP config.");
+      Serial.println("WiFi failed 3 times. Resetting credentials.");
       preferences.begin("wifi", false);
       preferences.clear();  // Erase bad credentials
       preferences.end();
-      startConfigPortal();
-      return false;
+      return false;  // configuration portal will be started by caller
     }
   } else {
     // Reset failure counter after a successful connection

--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -1,5 +1,11 @@
+// WiFiManager.h
 #ifndef WIFI_MANAGER_H
 #define WIFI_MANAGER_H
+
+#include <ESPAsyncWebServer.h>
+
+// Global web server used by both the WiFi config portal and the camera UI
+extern AsyncWebServer server;
 
 // Connect to WiFi using credentials saved in preferences.
 bool connectToStoredWiFi();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,9 +11,10 @@ void setup() {
 
   setupServos();  // hardware-safe init
 
-  // Start Wi-Fi
+  // Start Wi-Fi; if it fails, launch configuration portal and skip rest
   if (!connectToStoredWiFi()) {
-    startConfigPortal();  // blocks until user enters credentials
+    startConfigPortal();
+    return;  // remain in portal mode until restart
   }
 
   // Now that WiFi is confirmed working


### PR DESCRIPTION
## Summary
- expose global AsyncWebServer instance
- reuse server for camera UI instead of starting a second one
- skip camera startup when WiFi configuration portal is active

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_689685974ee0832280639c570731eb2f